### PR TITLE
Prevent overwriting of LANGUAGE envvar if not set

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -203,7 +203,11 @@ namespace SwitchboardPlugLocale {
 
             var lang_name = translate_language (Gnome.Languages.get_language_from_locale (locale, null));
 
-            Environment.set_variable ("LANGUAGE", current_language, true);
+            if (current_language != null) {
+                Environment.set_variable ("LANGUAGE", current_language, true);
+            } else {
+                Environment.unset_variable ("LANGUAGE");
+            }
 
             return lang_name;
         }
@@ -220,7 +224,11 @@ namespace SwitchboardPlugLocale {
             if (region.length == 2)
                 region_name = translate_country (Gnome.Languages.get_country_from_code (region, null));
 
-            Environment.set_variable ("LANGUAGE", current_language, true);
+            if (current_language != null) {
+                Environment.set_variable ("LANGUAGE", current_language, true);
+            } else {
+                Environment.unset_variable ("LANGUAGE");
+            }
  
             return region_name;
         }


### PR DESCRIPTION
Add a null check when restoring the envvar. If the `LANGUAGE` environment variable wasn't set in the first place, we end up stuck with the language set to whatever language was used to translate the string in this method.

Will fix https://github.com/elementary/os/issues/56