### PR TITLE
 build: fix install path for switchboard plug 

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ i18n.merge_file(
     output: 'io.elementary.switchboard.locale.policy',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'polkit-1', 'actions')
+    install_dir: join_paths(datadir, 'polkit-1', 'actions')
 )
 
 i18n.merge_file(
@@ -17,16 +17,16 @@ i18n.merge_file(
     output: '@BASENAME@',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: join_paths(datadir, 'metainfo')
 )
 
 install_data(
     'io.elementary.switchboard.locale.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )
 
 install_data(
     'languagelist',
     'packages_blacklist',
-    install_dir: pkg_data_dir
+    install_dir: pkgdatadir
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ i18n.merge_file(
     output: 'io.elementary.switchboard.locale.policy',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(datadir, 'polkit-1', 'actions')
+    install_dir: polkit_actiondir
 )
 
 i18n.merge_file(

--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,13 @@ project(
 
 gnome = import('gnome')
 i18n = import('i18n')
+
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
 switchboard_dep = dependency('switchboard-2.0')
-pkg_data_dir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal', 'pantheon-locale')
+pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal', 'pantheon-locale')
 
 
 add_project_arguments(
@@ -24,7 +29,7 @@ add_project_arguments(
 
 configuration_data = configuration_data()
 configuration_data.set('GETTEXT_PACKAGE', meson.project_name())
-configuration_data.set('PKGDATADIR', pkg_data_dir)
+configuration_data.set('PKGDATADIR', pkgdatadir)
 
 constants = configure_file(
     configuration: configuration_data,

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,8 @@ datadir = join_paths(prefix, get_option('datadir'))
 libdir = join_paths(prefix, get_option('libdir'))
 
 switchboard_dep = dependency('switchboard-2.0')
-pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal', 'pantheon-locale')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
+pkgdatadir = join_paths(switchboard_plugsdir, 'personal', 'pantheon-locale')
 
 
 add_project_arguments(

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 pkgdatadir = join_paths(switchboard_plugsdir, 'personal', 'pantheon-locale')
 
+polkit_dep = dependency('polkit-gobject-1')
+polkit_actiondir = polkit_dep.get_pkgconfig_variable('actiondir', define_variable: ['prefix', prefix])
 
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,17 +28,17 @@ shared_module(
     constants,
     dependencies: [
         dependency('accountsservice'),
-        dependency('glib-2.0'),
         dependency('gio-2.0'),
+        dependency('glib-2.0'),
         dependency('gnome-desktop-3.0'),
         dependency('gobject-2.0'),
         dependency('granite'),
         dependency('gtk+-3.0'),
         dependency('ibus-1.0'),
-        dependency('polkit-gobject-1'),
-        vala_compiler.find_library('posix'),
+        polkit_dep,
+        switchboard_dep,
         vala_compiler.find_library('monetary', dirs: join_paths(meson.source_root(), 'vapi')),
-        switchboard_dep
+        vala_compiler.find_library('posix'),
     ],
     install: true,
     install_dir : join_paths(switchboard_plugsdir, 'personal')

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,5 +41,5 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
+    install_dir : join_paths(switchboard_plugsdir, 'personal')
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.

---

Also includes https://github.com/elementary/switchboard-plug-locale/commit/ce595b48bf15243bfea0198450a91340525d8cf2 for completion.