### PR TITLE
Make UbuntuInstaller a singleton

### DIFF
--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -43,8 +43,16 @@ namespace SwitchboardPlugLocale.Installer {
 
         Gee.HashMap<string, string> transactions;
 
-        public UbuntuInstaller () {
+        private static GLib.Once<UbuntuInstaller> instance;
+        public static unowned UbuntuInstaller get_default () {
+            return instance.once (() => {
+                return new UbuntuInstaller ();
+            });
+        }
 
+        private UbuntuInstaller () {}
+
+        construct {
             transactions = new Gee.HashMap<string, string> ();
             aptd = new AptdProxy ();
 

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -19,7 +19,7 @@ namespace SwitchboardPlugLocale {
         Gtk.Grid grid;
         Widgets.LocaleView view;
 
-        public Installer.UbuntuInstaller installer;
+        private Installer.UbuntuInstaller installer;
         public Gtk.InfoBar infobar;
         public Gtk.InfoBar permission_infobar;
         public Gtk.InfoBar missing_lang_infobar;
@@ -41,7 +41,7 @@ namespace SwitchboardPlugLocale {
         public override Gtk.Widget get_widget () {
             if (grid == null) {
                 Utils.init ();
-                installer = new Installer.UbuntuInstaller ();
+                installer = Installer.UbuntuInstaller.get_default ();
 
                 setup_ui ();
                 setup_info ();

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -80,13 +80,11 @@ namespace SwitchboardPlugLocale {
             installer.install_finished.connect ((langcode) => {
                 langs.add (langcode);
                 reload.begin ();
-                view.make_sensitive (true);
             });
 
             installer.remove_finished.connect ((langcode) => {
                 langs.remove (langcode);
                 reload.begin ();
-                view.make_sensitive (true);
             });
 
             installer.check_missing_finished.connect (on_check_missing_finished);
@@ -165,7 +163,7 @@ namespace SwitchboardPlugLocale {
                 return;
             }
 
-            progress_dialog = new ProgressDialog (installer);
+            progress_dialog = new ProgressDialog ();
             progress_dialog.progress = progress;
             progress_dialog.transient_for = (Gtk.Window) grid.get_toplevel ();
             progress_dialog.run ();

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -19,11 +19,11 @@ namespace SwitchboardPlugLocale {
         Gtk.Grid grid;
         Widgets.LocaleView view;
 
-        private Installer.UbuntuInstaller installer;
         public Gtk.InfoBar infobar;
         public Gtk.InfoBar permission_infobar;
         public Gtk.InfoBar missing_lang_infobar;
 
+        private Installer.UbuntuInstaller installer;
         private ProgressDialog progress_dialog = null;
 
         private Gee.ArrayList<string> langs;

--- a/src/ProgressDialog.vala
+++ b/src/ProgressDialog.vala
@@ -30,7 +30,7 @@ public class SwitchboardPlugLocale.ProgressDialog : Gtk.Dialog {
         var image = new Gtk.Image.from_icon_name ("preferences-desktop-locale", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
-        var installer = Installer.UbuntuInstaller.get_default ();
+        unowned Installer.UbuntuInstaller installer = Installer.UbuntuInstaller.get_default ();
 
         var transaction_language_name = Utils.translate (installer.transaction_language_code, null);
 

--- a/src/ProgressDialog.vala
+++ b/src/ProgressDialog.vala
@@ -24,17 +24,13 @@ public class SwitchboardPlugLocale.ProgressDialog : Gtk.Dialog {
         }
     }
 
-    public Installer.UbuntuInstaller installer { get; construct; }
-
     private Gtk.ProgressBar progress_bar;
-
-    public ProgressDialog (Installer.UbuntuInstaller installer) {
-        Object (installer: installer);
-    }
 
     construct {
         var image = new Gtk.Image.from_icon_name ("preferences-desktop-locale", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
+
+        var installer = Installer.UbuntuInstaller.get_default ();
 
         var transaction_language_name = Utils.translate (installer.transaction_language_code, null);
 

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -86,13 +86,23 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
             });
 
+            var installer = Installer.UbuntuInstaller.get_default ();
+
+            installer.install_finished.connect (() => {
+                make_sensitive (true);
+            });
+
+            installer.remove_finished.connect (() => {
+                make_sensitive (true);
+            });
+
             remove_button.clicked.connect (() => {
                 if (!Utils.allowed_permission ()) {
                     return;
                 }
 
                 make_sensitive (false);
-                Installer.UbuntuInstaller.get_default ().remove (list_box.get_selected_language_code ());
+                installer.remove (list_box.get_selected_language_code ());
             });
 
             popover.language_selected.connect ((lang) => {
@@ -101,7 +111,7 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
 
                 make_sensitive (false);
-                Installer.UbuntuInstaller.get_default ().install (lang);
+                installer.install (lang);
             });
 
             show_all ();

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -86,7 +86,7 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
             });
 
-            var installer = Installer.UbuntuInstaller.get_default ();
+            unowned Installer.UbuntuInstaller installer = Installer.UbuntuInstaller.get_default ();
 
             installer.install_finished.connect (() => {
                 make_sensitive (true);

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -92,7 +92,7 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
 
                 make_sensitive (false);
-                plug.installer.remove (list_box.get_selected_language_code ());
+                Installer.UbuntuInstaller.get_default ().remove (list_box.get_selected_language_code ());
             });
 
             popover.language_selected.connect ((lang) => {

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -101,13 +101,13 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
 
                 make_sensitive (false);
-                plug.installer.install (lang);
+                Installer.UbuntuInstaller.get_default ().install (lang);
             });
 
             show_all ();
         }
 
-        public void make_sensitive (bool sensitive) {
+        private void make_sensitive (bool sensitive) {
             sidebar.sensitive = sensitive;
             locale_setting.sensitive = sensitive;
         }


### PR DESCRIPTION
This will enable us to stop passing around signals in future branches, since we need access to this from a couple different places