### PR TITLE
Plug.vala: Animate infobar hide/show for missing languages

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -127,6 +127,7 @@ namespace SwitchboardPlugLocale {
 
             missing_lang_infobar = new Gtk.InfoBar ();
             missing_lang_infobar.message_type = Gtk.MessageType.WARNING;
+            missing_lang_infobar.revealed = false;
             missing_lang_infobar.add_button (_("Complete Installation"), 0);
             missing_lang_infobar.get_content_area ().add (missing_label);
 
@@ -140,7 +141,7 @@ namespace SwitchboardPlugLocale {
             grid.show ();
 
             missing_lang_infobar.response.connect (() => {
-                missing_lang_infobar.hide ();
+                missing_lang_infobar.revealed = false;
                 installer.install_missing_languages ();
             });
         }
@@ -152,10 +153,10 @@ namespace SwitchboardPlugLocale {
 
         private void on_check_missing_finished (string[] missing) {
             if (missing.length > 0) {
-                missing_lang_infobar.show ();
                 missing_lang_infobar.show_all ();
+                missing_lang_infobar.revealed = true;
             } else {
-                missing_lang_infobar.hide ();
+                missing_lang_infobar.revealed = false;
             }
         }
 


### PR DESCRIPTION
Animate the missing languages infobar!

![anim](https://user-images.githubusercontent.com/8471701/64895971-2e0d6880-d64c-11e9-81bc-d0fff6681c59.gif)
