### PR TITLE
lint src directory files via vala-lint

### DIFF
--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -62,7 +62,7 @@ namespace SwitchboardPlugLocale.Installer {
             transaction_language_code = language;
 
             foreach (var packet in packages) {
-                message("Packet: %s", packet);
+                message ("Packet: %s", packet);
             }
 
             aptd.install_packages.begin (packages, (obj, res) => {
@@ -122,7 +122,7 @@ namespace SwitchboardPlugLocale.Installer {
 
                 try {
                     var transaction_id = aptd.remove_packages.end (res);
-                    transactions.@set (transaction_id, "r-"+languagecode);
+                    transactions.@set (transaction_id, "r-" + languagecode);
                     run_transaction (transaction_id);
 
                 } catch (Error e) {

--- a/src/Installer/aptd-client.vala
+++ b/src/Installer/aptd-client.vala
@@ -28,7 +28,7 @@ public interface AptdService: GLib.Object {
     public abstract async string remove_packages (string[] packages) throws GLib.Error;
     public abstract async void quit () throws GLib.Error;
 }
-  
+
 [DBus (name = "org.debian.apt.transaction")]
 public interface AptdTransactionService: GLib.Object {
     public abstract void run () throws GLib.Error;
@@ -37,7 +37,7 @@ public interface AptdTransactionService: GLib.Object {
     public signal void finished (string exit_state);
     public signal void property_changed (string property, Variant val);
 }
-  
+
 public class AptdProxy: GLib.Object {
     public void connect_to_aptd () throws GLib.Error {
       _aptd_service = Bus.get_proxy_sync (BusType.SYSTEM, APTD_DBUS_NAME, APTD_DBUS_PATH);

--- a/src/LocaleManager.vala
+++ b/src/LocaleManager.vala
@@ -25,7 +25,14 @@ public interface AccountProxy : GLib.Object {
 [DBus (name = "org.freedesktop.locale1")]
 public interface Locale1Proxy : GLib.Object {
     public abstract void set_locale (string[] arg_0, bool arg_1) throws GLib.Error;
-    public abstract void set_x11_keyboard (string arg_0, string arg_1, string arg_2, string arg_3, bool arg_4, bool arg_5) throws GLib.Error;
+    public abstract void set_x11_keyboard (
+        string arg_0,
+        string arg_1,
+        string arg_2,
+        string arg_3,
+        bool arg_4,
+        bool arg_5
+    ) throws GLib.Error;
 }
 
 namespace SwitchboardPlugLocale {
@@ -53,8 +60,16 @@ namespace SwitchboardPlugLocale {
 
             try {
                 var connection = Bus.get_sync (BusType.SYSTEM);
-                locale1_proxy = connection.get_proxy_sync<Locale1Proxy> ("org.freedesktop.locale1", "/org/freedesktop/locale1", DBusProxyFlags.NONE);
-                account_proxy = connection.get_proxy_sync<AccountProxy> ("org.freedesktop.Accounts", "/org/freedesktop/Accounts/User%u".printf (uid), DBusProxyFlags.NONE);
+                locale1_proxy = connection.get_proxy_sync<Locale1Proxy> (
+                    "org.freedesktop.locale1",
+                    "/org/freedesktop/locale1",
+                    DBusProxyFlags.NONE
+                );
+                account_proxy = connection.get_proxy_sync<AccountProxy> (
+                    "org.freedesktop.Accounts",
+                    "/org/freedesktop/Accounts/User%u".printf (uid),
+                    DBusProxyFlags.NONE
+                );
             } catch (IOError e) {
                 critical (e.message);
             }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -104,7 +104,10 @@ namespace SwitchboardPlugLocale {
 
         // 'search' returns results like ("Keyboard → Behavior → Duration", "keyboard<sep>behavior")
         public override async Gee.TreeMap<string, string> search (string search) {
-            var search_results = new Gee.TreeMap<string, string> ((GLib.CompareDataFunc<string>)strcmp, (Gee.EqualDataFunc<string>)str_equal);
+            var search_results = new Gee.TreeMap<string, string> (
+                (GLib.CompareDataFunc<string>)strcmp,
+                (Gee.EqualDataFunc<string>)str_equal
+            );
             search_results.set ("%s → %s".printf (display_name, _("Region")), "");
             search_results.set ("%s → %s".printf (display_name, _("Formats")), "");
             search_results.set ("%s → %s".printf (display_name, _("Temperature")), "");

--- a/src/Widgets/InstallPopover.vala
+++ b/src/Widgets/InstallPopover.vala
@@ -93,14 +93,19 @@ namespace SwitchboardPlugLocale.Widgets {
                 string line;
                 var langs = new GLib.List<string> ();
                 while ((line = dis.read_line (null)) != null) {
-                    if (line.substring(0,1) != "#" && line != "") {
+                    if (line.substring (0, 1) != "#" && line != "") {
                         if (line == "ia")
                             continue;
 
                         if (langs.find_custom (line, strcmp).length () == 0) {
                             Gtk.TreeIter iter;
                             list_store.append (out iter);
-                            list_store.set (iter, 0, Utils.translate (line, null), 1, Utils.translate (line, "C"), 2, line);
+                            list_store.set (
+                                iter, 0,
+                                Utils.translate (line, null), 1,
+                                Utils.translate (line, "C"), 2,
+                                line
+                            );
                             langs.append (line);
                         }
                     }


### PR DESCRIPTION
This fixes linting errors in the src directory.

## Run vala-lint locally:

Assuming you have [vala-lint](https://github.com/elementary/vala-lint) installed locally:
```sh
io.elementary.vala-lint -d src
```

## Run vala-lint via a container:
Assuming you have docker installed locally:
```sh
docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint io.elementary.vala-lint -d src
```