### PR TITLE
Update the languages list on adding/removing a language

### DIFF
--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -69,7 +69,7 @@ namespace SwitchboardPlugLocale.Installer {
 
                 try {
                     var transaction_id = aptd.install_packages.end (res);
-                    transactions.@set (transaction_id, "i- " + language);
+                    transactions.@set (transaction_id, "i-" + language);
                     run_transaction (transaction_id);
                 } catch (Error e) {
                     warning ("Could not queue downloads: %s", e.message);

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -26,6 +26,8 @@ namespace SwitchboardPlugLocale {
 
         private ProgressDialog progress_dialog = null;
 
+        private Gee.ArrayList<string> langs;
+
         public Plug () {
             var settings = new Gee.TreeMap<string, string?> (null, null);
             settings.set ("language", null);
@@ -52,7 +54,7 @@ namespace SwitchboardPlugLocale {
 
         private async void reload () {
             new Thread<void*> ("load-lang-data", () => {
-                var langs = Utils.get_installed_languages ();
+                langs = Utils.get_installed_languages ();
                 var locales = Utils.get_installed_locales ();
 
                 Idle.add (() => {
@@ -76,12 +78,13 @@ namespace SwitchboardPlugLocale {
             }
 
             installer.install_finished.connect ((langcode) => {
+                langs.add (langcode);
                 reload.begin ();
                 view.make_sensitive (true);
             });
 
             installer.remove_finished.connect ((langcode) => {
-                view.list_box.remove_language (langcode);
+                langs.remove (langcode);
                 reload.begin ();
                 view.make_sensitive (true);
             });

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -16,7 +16,7 @@
 
 namespace SwitchboardPlugLocale {
     public class Utils : Object {
-        private static string[] installed_languages;
+        private static Gee.ArrayList<string> installed_languages;
         private static Gee.ArrayList<string> installed_locales;
         private static Gee.HashMap<string, string> default_regions;
         private static Gee.ArrayList<string> blacklist_packages;
@@ -25,11 +25,11 @@ namespace SwitchboardPlugLocale {
             installed_locales = new Gee.ArrayList<string> ();
             default_regions = new Gee.HashMap<string, string> ();
             blacklist_packages = new Gee.ArrayList<string> ();
-            installed_languages = {};
+            installed_languages = new Gee.ArrayList<string> ();
         }
 
-        public static string[]? get_installed_languages () {
-            if (installed_languages.length > 0) {
+        public static Gee.ArrayList<string>? get_installed_languages () {
+            if (installed_languages.size > 0) {
                 return installed_languages;
             }
 
@@ -46,7 +46,9 @@ namespace SwitchboardPlugLocale {
                     null,
                     out status);
 
-                installed_languages = output.split ("\n");
+                foreach (var lang in output.split ("\n")) {
+                    installed_languages.add (lang);
+                }
             } catch (Error e) {
                 warning (e.message);
             }

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -39,7 +39,7 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         });
 
         langs.sort ((a, b) => {
-            return ((string) a).collate ((string) b);
+            return a.collate (b);
         });
 
         for (int i = 0; i < langs.size; i++) {

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -38,6 +38,10 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
             this.remove (item);
         });
 
+        langs.sort ((a, b) => {
+            return ((string) a).collate ((string) b);
+        });
+
         for (int i = 0; i < langs.size; i++) {
             var language = langs[i];
             var code = language.slice (0, 2);

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -31,14 +31,15 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         set_header_func (update_headers);
     }
 
-    public void reload_languages (string[] langs) {
+    public void reload_languages (Gee.ArrayList<string> langs) {
         //clear hashmap and this listbox
         languages.clear ();
         this.foreach ((item) => {
             this.remove (item);
         });
 
-        foreach (var language in langs) {
+        for (int i = 0; i < langs.size; i++) {
+            var language = langs[i];
             var code = language.slice (0, 2);
             if (language.length == 2 || language.length == 5) {
                 add_language (code);
@@ -68,12 +69,6 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         }
 
         show_all ();
-    }
-
-    public void remove_language (string code) {
-        if (languages.has_key (code)) {
-            languages[code].destroy ();
-        }
     }
 
     public void set_current (string code) {


### PR DESCRIPTION
Fixes #102
Supersedes #103

## Changes Summary

* Remove an unnecessary space from transaction_id (its format was `"r-" + <language code>` for removal, but `"i- " + <language code>` for installation, which causes wrong langcode output)
* Use `Gee.ArrayList` instead of `string[]` (because the latter does not seem to support removing elements?)
* Add/remove the designated language to/from the languages list on adding/removing the language
