### PR TITLE
Set sensitivity of set_system_button depends on the selected language and system language

### DIFF
--- a/src/LocaleManager.vala
+++ b/src/LocaleManager.vala
@@ -191,6 +191,34 @@ namespace SwitchboardPlugLocale {
             }
         }
 
+        public string get_system_language () {
+            string result = "";
+            string prefix = "LANG=";
+
+            try {
+                string localectl_output;
+                Process.spawn_sync (null,
+                    {"/usr/bin/localectl", "status"},
+                    Environ.get (),
+                    SpawnFlags.SEARCH_PATH,
+                    null, out localectl_output);
+
+                foreach (string line in localectl_output.split ("\n")) {
+                    if ("System Locale" in line) {
+                        foreach (string splitted in line.split (":")) {
+                            if (prefix in splitted) {
+                                result = splitted.strip ();
+                            }
+                        }
+                    }
+                }
+            } catch (Error e) {
+                critical (e.message);
+            }
+
+            return result[prefix.length:prefix.length + 5];
+        }
+
         public void apply_to_system (string language, string? format) {
             /*
              * This is a temporary solution for setting the system-wide locale.

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -17,6 +17,7 @@
 namespace SwitchboardPlugLocale.Widgets {
     public class LocaleSetting : Granite.SimpleSettingsPage {
         private Gtk.Button set_button;
+        private Gtk.Button set_system_button;
         private Gtk.ComboBox format_combobox;
         private Gtk.ComboBox region_combobox;
         private Gtk.ListStore format_store;
@@ -105,7 +106,7 @@ namespace SwitchboardPlugLocale.Widgets {
             set_button.sensitive = false;
             set_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
-            var set_system_button = new Gtk.Button.with_label (_("Set System Language"));
+            set_system_button = new Gtk.Button.with_label (_("Set System Language"));
             set_system_button.tooltip_text = _("Set language for login screen, guest account and new user accounts");
 
             var keyboard_button = new Gtk.Button.with_label (_("Keyboard Settings…"));
@@ -197,7 +198,7 @@ namespace SwitchboardPlugLocale.Widgets {
         }
 
         private void compare () {
-            if (set_button != null && selected_language != "" && selected_format != "") {
+            if (set_button != null && set_system_button != null && selected_language != "" && selected_format != "") {
                 var compare_language = language;
                 if (has_region) {
                     compare_language = "%s_%s".printf (compare_language, get_region ());
@@ -207,6 +208,12 @@ namespace SwitchboardPlugLocale.Widgets {
                     set_button.sensitive = false;
                 } else {
                     set_button.sensitive = true;
+                }
+
+                if (compare_language == lm.get_system_language () && selected_format == get_format ()) {
+                    set_system_button.sensitive = false;
+                } else {
+                    set_system_button.sensitive = true;
                 }
             }
         }


### PR DESCRIPTION
![Screenshot from 2019-09-21 21-25-01](https://user-images.githubusercontent.com/26003928/65373301-87ae0c80-dcb6-11e9-8a44-ea46bc3ebd67.png)

The "Set System Language" button should be insensitive if the currently selected language is the same as the system language, as the "Set Language" button gets insensitive if the currently selected language is the same as the user language.

## TODO

* [ ] Make it work with languages that don't need regions (like ja_JP because there're no region that uses Japanese, while French needs to specify a region like fr_FR or fr_CA for example)
* [ ] Improve readability
