### PR TITLE
Make the installation trigger code more readable

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -150,11 +150,6 @@ namespace SwitchboardPlugLocale {
             });
         }
 
-        public void on_install_language (string language) {
-            view.make_sensitive (false);
-            installer.install (language);
-        }
-
         private void on_check_missing_finished (string[] missing) {
             if (missing.length > 0) {
                 missing_lang_infobar.show_all ();

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -100,7 +100,8 @@ namespace SwitchboardPlugLocale.Widgets {
                     return;
                 }
 
-                plug.on_install_language (lang);
+                make_sensitive (false);
+                plug.installer.install (lang);
             });
 
             show_all ();


### PR DESCRIPTION
Because the `on_install_language` method is accessed only from the `language_selected` signal of the popover in LocaleView.vala and considering unifying the code format to the signal of remove_button above the `language_selected` signal, I personally think this makes more sense.
