### PR TITLE
Fix the property 'install-cancellable' warning

### DIFF
--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -21,7 +21,7 @@ public class SwitchboardPlugLocale.Installer.UbuntuInstaller : Object {
     private AptdTransactionProxy proxy;
 
     private string []? missing_packages = null;
-    private bool install_cancellable;
+    public bool install_cancellable { get; private set; }
     public TransactionMode transaction_mode { get; private set; }
     public string transaction_language_code { get; private set; }
 


### PR DESCRIPTION
Fixes the following warning is shown when installing/removing a language:

```
(io.elementary.switchboard:8612): GLib-GObject-WARNING **: 16:07:38.596: ../../../../gobject/gbinding.c:857: The source object of type SwitchboardPlugLocaleInstallerUbuntuInstaller has no property called 'install-cancellable'
```
