### PR TITLE
LocaleSetting: lookup schemas recursive

### DIFF
--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -157,7 +157,7 @@ namespace SwitchboardPlugLocale.Widgets {
         }
 
         static construct {
-            if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather", false) != null) {
+            if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather", true) != null) {
                 temperature_settings = new Settings ("org.gnome.GWeather");
             }
         }


### PR DESCRIPTION
The docs on SettingsSchemaSource get_default say
```
The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.
```

Without this in NixOS it will not work as intended, as we
have multiple entries in XDG_DATA_DIRS.