### PR TITLE
Utils: Replace usage of language-options

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -182,8 +182,10 @@ namespace SwitchboardPlugLocale {
         public static Gee.ArrayList<string> get_regions (string language) {
             Gee.ArrayList<string> regions = new Gee.ArrayList<string> ();
             foreach (string locale in get_installed_languages ()) {
-                string code = locale.slice (0, 2);
-                string region = locale.slice (3, 5);
+                string code, region, codeset, modifier;
+                if (!Gnome.Languages.parse_locale (locale, out code, out region, out codeset, out modifier)) {
+                    continue;
+                }
 
                 if (!regions.contains (region) && code == language) {
                     regions.add (region);

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -25,32 +25,16 @@ namespace SwitchboardPlugLocale {
             installed_locales = new Gee.ArrayList<string> ();
             default_regions = new Gee.HashMap<string, string> ();
             blacklist_packages = new Gee.ArrayList<string> ();
-            installed_languages = new Gee.ArrayList<string> ();
         }
 
         public static Gee.ArrayList<string>? get_installed_languages () {
-            if (installed_languages.size > 0) {
+            if (installed_languages != null) {
                 return installed_languages;
             }
 
-            string output;
-            int status;
-
-            try {
-                Process.spawn_sync (null,
-                    {"/usr/share/language-tools/language-options", null},
-                    Environ.get (),
-                    SpawnFlags.SEARCH_PATH,
-                    null,
-                    out output,
-                    null,
-                    out status);
-
-                foreach (var lang in output.split ("\n")) {
-                    installed_languages.add (lang);
-                }
-            } catch (Error e) {
-                warning (e.message);
+            installed_languages = new Gee.ArrayList<string>.wrap (Gnome.Languages.get_all_locales ());
+            foreach (var lang in installed_languages) {
+                stdout.printf ("%s\n", lang);
             }
 
             return installed_languages;
@@ -201,13 +185,11 @@ namespace SwitchboardPlugLocale {
         public static Gee.ArrayList<string> get_regions (string language) {
             Gee.ArrayList<string> regions = new Gee.ArrayList<string> ();
             foreach (string locale in get_installed_languages ()) {
-                if (locale.length == 5) {
-                    string code = locale.slice (0, 2);
-                    string region = locale.slice (3, 5);
+                string code = locale.slice (0, 2);
+                string region = locale.slice (3, 5);
 
-                    if (!regions.contains (region) && code == language) {
-                        regions.add (region);
-                    }
+                if (!regions.contains (region) && code == language) {
+                    regions.add (region);
                 }
             }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -33,9 +33,6 @@ namespace SwitchboardPlugLocale {
             }
 
             installed_languages = new Gee.ArrayList<string>.wrap (Gnome.Languages.get_all_locales ());
-            foreach (var lang in installed_languages) {
-                stdout.printf ("%s\n", lang);
-            }
 
             return installed_languages;
         }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -182,8 +182,8 @@ namespace SwitchboardPlugLocale {
         public static Gee.ArrayList<string> get_regions (string language) {
             Gee.ArrayList<string> regions = new Gee.ArrayList<string> ();
             foreach (string locale in get_installed_languages ()) {
-                string code, region, codeset, modifier;
-                if (!Gnome.Languages.parse_locale (locale, out code, out region, out codeset, out modifier)) {
+                string code, region;
+                if (!Gnome.Languages.parse_locale (locale, out code, out region, null, null)) {
                     continue;
                 }
 

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -45,9 +45,7 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         for (int i = 0; i < langs.size; i++) {
             var language = langs[i];
             var code = language.slice (0, 2);
-            if (language.length == 2 || language.length == 5) {
-                add_language (code);
-            }
+            add_language (code);
         }
 
         foreach (Gtk.Widget row in get_children ()) {

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -42,9 +42,12 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
             return a.collate (b);
         });
 
-        for (int i = 0; i < langs.size; i++) {
-            var language = langs[i];
-            var code = language.slice (0, 2);
+        foreach (var locale in langs) {
+            string code, region, codeset, modifier;
+            if (!Gnome.Languages.parse_locale (locale, out code, out region, out codeset, out modifier)) {
+                continue;
+            }
+
             add_language (code);
         }
 

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -43,8 +43,8 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         });
 
         foreach (var locale in langs) {
-            string code, region, codeset, modifier;
-            if (!Gnome.Languages.parse_locale (locale, out code, out region, out codeset, out modifier)) {
+            string code;
+            if (!Gnome.Languages.parse_locale (locale, out code, null, null, null)) {
                 continue;
             }
 


### PR DESCRIPTION
`language-options` is an Ubuntu-specific perl script installed as an extension to AccountsService.

`libgnome-desktop` provides `Gnome.Languages.get_all_locales` that achieves the same thing in a way that will work on other distros.

I've also removed the hardcoded length checks on the locales as this would have been preventing some of the 3 letter locales from being parsed and displayed. There's a GNOME method that can do that parsing for us.

There's a bunch of other Ubuntu specific stuff in this plug, but I'll make changes in small increments like this so we can test it a bit a time. This changes how the lists of available languages and regions are loaded. On Odin, this has no effect on the top level list of "installed languages", but there seem to be more regions available with this branch (which I guess isn't a bad thing).