### PR TITLE
Remove the remaining manual locale parsing

### DIFF
--- a/src/LocaleManager.vala
+++ b/src/LocaleManager.vala
@@ -24,6 +24,8 @@ public interface AccountProxy : GLib.Object {
 
 [DBus (name = "org.freedesktop.locale1")]
 public interface Locale1Proxy : GLib.Object {
+    public abstract string[] locale { owned get; }
+
     public abstract void set_locale (string[] arg_0, bool arg_1) throws GLib.Error;
     public abstract void set_x11_keyboard (
         string arg_0,
@@ -189,6 +191,16 @@ namespace SwitchboardPlugLocale {
                     throw e;
                 }
             }
+        }
+
+        public string? get_system_locale () {
+            foreach (unowned var locale in locale1_proxy.locale) {
+                if (locale.has_prefix ("LANG=")) {
+                    return locale.replace ("LANG=", "");
+                }
+            }
+
+            return null;
         }
 
         public void apply_to_system (string language, string? format) {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -23,7 +23,6 @@ namespace SwitchboardPlugLocale {
 
         public static void init () {
             installed_locales = new Gee.ArrayList<string> ();
-            default_regions = new Gee.HashMap<string, string> ();
             blacklist_packages = new Gee.ArrayList<string> ();
         }
 
@@ -151,11 +150,9 @@ namespace SwitchboardPlugLocale {
         }
 
         public static async Gee.HashMap<string, string>? get_default_regions () {
-            if (default_regions.size > 0) {
+            if (default_regions != null) {
                 return default_regions;
             }
-
-            default_regions = new Gee.HashMap<string, string> ();
 
             uint8[] data;
             try {
@@ -163,7 +160,10 @@ namespace SwitchboardPlugLocale {
                 yield file.load_contents_async (null, out data, null);
             } catch (Error e) {
                 warning (e.message);
+                return null;
             }
+
+            default_regions = new Gee.HashMap<string, string> ();
 
             string contents = (string)data;
             var output_array = contents.split ("\n");

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -64,7 +64,20 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.ListBox {
         if (!languages.has_key (code)) {
             var language_string = Utils.translate (code, null);
 
-            if (lm.get_user_language ().slice (0, 2) == code) {
+            string user_lang = lm.get_user_language ();
+            // If accountsservice doesn't have a specific language for the user, then get the system locale
+            if (user_lang == null || user_lang.length == 0) {
+                // If we can't get a system locale either, fall back to displaying the user as using en_US
+                user_lang = lm.get_system_locale () ?? "en_US.UTF-8";
+            }
+
+            string user_lang_code;
+            if (!Gnome.Languages.parse_locale (user_lang, out user_lang_code, null, null, null)) {
+                // If we somehow still ended up with an invalid locale, display the user as using English
+                user_lang_code = "en";
+            }
+
+            if (user_lang_code == code) {
                 languages[code] = new LanguageRow (code, language_string, true);
             } else {
                 languages[code] = new LanguageRow (code, language_string);

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -226,6 +226,21 @@ namespace SwitchboardPlugLocale.Widgets {
 
             region_store.clear ();
 
+            var user_lang = lm.get_user_language ();
+             // If accountsservice doesn't have a specific language for the user, then get the system locale
+            if (user_lang.length == 0) {
+                 // If we can't get a system locale either, fall back to displaying the user as using en_US
+                user_lang = lm.get_system_locale () ?? "en_US.UTF-8";
+            }
+
+            string user_code, user_region;
+            if (!Gnome.Languages.parse_locale (user_lang, out user_code, out user_region, null, null)) {
+                user_code = "en";
+                user_region = "US";
+            }
+
+            var default_regions = yield Utils.get_default_regions ();
+
             int i = 0;
             has_region = false;
             foreach (var region in regions) {
@@ -236,13 +251,11 @@ namespace SwitchboardPlugLocale.Widgets {
                 region_store.append (out iter);
                 region_store.set (iter, 0, region_string, 1, region);
 
-                if (lm.get_user_language ().length == 5 && lm.get_user_language ().slice (0, 2) == language
-                    && lm.get_user_language ().slice (3, 5) == region) {
-                        selected_region = i;
+                if (user_code == language && user_region == region) {
+                    selected_region = i;
                 }
 
-                var default_regions = yield Utils.get_default_regions ();
-                if (default_regions.has_key (language) && lm.get_user_language ().slice (0, 2) != language
+                if (default_regions != null && default_regions.has_key (language) && user_code != language
                 && default_regions.@get (language) == "%s_%s".printf (language, region)) {
                     selected_region = i;
                 }

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -79,7 +79,27 @@ namespace SwitchboardPlugLocale.Widgets {
                 locale_setting.reload_regions (selected_language_code, regions);
                 locale_setting.reload_labels (selected_language_code);
 
-                if (selected_language_code == locale_manager.get_user_language ().slice (0, 2)) {
+                string user_lang = locale_manager.get_user_language ();
+                // If accountsservice doesn't have a specific language for the user, then get the system locale
+                if (user_lang == null || user_lang.length == 0) {
+                    // If we can't get a system locale either, fall back to displaying the user as using en_US
+                    user_lang = locale_manager.get_system_locale () ?? "en_US.UTF-8";
+                }
+
+                string user_lang_code;
+                if (!Gnome.Languages.parse_locale (user_lang, out user_lang_code, null, null, null)) {
+                    // If we somehow still ended up with an invalid locale, display the user as using English
+                    user_lang_code = "en";
+                }
+
+                string system_lang = locale_manager.get_system_locale () ?? "en_US.UTF-8";
+                string system_lang_code;
+                if (!Gnome.Languages.parse_locale (system_lang, out system_lang_code, null, null, null)) {
+                    system_lang_code = "en";
+                }
+
+                // Prevent removing the user's locale and the systemwide locale
+                if (selected_language_code == user_lang_code || selected_language_code == system_lang_code) {
                     remove_button.sensitive = false;
                 } else {
                     remove_button.sensitive = true;


### PR DESCRIPTION
Follow up to #138 

Removes the remainder of the old string length based parsing of locale codes and some better error handling.