### PR TITLE
Get available formats from libgnome-desktop

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -58,11 +58,10 @@ namespace SwitchboardPlugLocale {
         private async void reload () {
             new Thread<void*> ("load-lang-data", () => {
                 langs = Utils.get_installed_languages ();
-                var locales = Utils.get_installed_locales ();
 
                 Idle.add (() => {
                     view.list_box.reload_languages (langs);
-                    view.locale_setting.reload_formats (locales);
+                    view.locale_setting.reload_formats (langs);
                     return false;
                 });
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -119,37 +119,6 @@ namespace SwitchboardPlugLocale {
             }
         }
 
-        public static Gee.ArrayList<string> get_installed_locales () {
-            if (installed_locales.size > 0) {
-                return installed_locales;
-            }
-
-            string output;
-            int status;
-
-            try {
-                Process.spawn_sync (null,
-                    {"locale", "-a", null},
-                    Environ.get (),
-                    SpawnFlags.SEARCH_PATH,
-                    null,
-                    out output,
-                    null,
-                    out status);
-
-                foreach (var line in output.split ("\n")) {
-                    if (".utf8" in line) {
-                        var locale = line.substring (0, line.index_of (".utf8"));
-                        installed_locales.add (locale);
-                    }
-                }
-            } catch (Error e) {
-                warning (e.message);
-            }
-
-            return installed_locales;
-        }
-
         public static async Gee.HashMap<string, string>? get_default_regions () {
             if (default_regions.size > 0) {
                 return default_regions;

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -278,16 +278,9 @@ namespace SwitchboardPlugLocale.Widgets {
 
             int i = 0;
             foreach (var locale in locales) {
-                string country = null;
-
-                if (locale.length == 2) {
-                    country = Gnome.Languages.get_country_from_code (locale, null);
-                } else if (locale.length == 5) {
-                    country = Gnome.Languages.get_country_from_locale (locale, null);
-                }
+                string country = Gnome.Languages.get_country_from_locale (locale, null);
 
                 if (country != null) {
-                    locale += ".UTF-8";
                     var iter = Gtk.TreeIter ();
                     format_store.append (out iter);
                     format_store.set (iter, 0, country, 1, locale);
@@ -299,6 +292,7 @@ namespace SwitchboardPlugLocale.Widgets {
                     i++;
                 }
             }
+
             format_combobox.sensitive = i != 1; // set to unsensitive if only have one item
             format_combobox.active = format_id;
 


### PR DESCRIPTION
We don't need to run `locale -a`, filter it down the `utf8` formats, then manually replace and add `.UTF-8` onto them when libgnome-desktop already provides the locales in the right format for us.

To test:
* Check the "Formats" dropdown still contains a sensible list of locales we can set the formats from