### PR TITLE
Set locale including codeset

### DIFF
--- a/src/LocaleManager.vala
+++ b/src/LocaleManager.vala
@@ -110,7 +110,14 @@ namespace SwitchboardPlugLocale {
         }
 
         public string get_user_language () {
-            return account_proxy.language;
+            // AccountsService on Ubuntu seems to strip off the codepage, so we put it back here
+            // so that we can match it against the locales installed on the system
+            var lang = account_proxy.language;
+            if (!lang.contains (".UTF-8")) {
+                lang = lang + ".UTF-8";
+            }
+
+            return lang;
         }
 
         public void set_user_format (string language) {
@@ -201,11 +208,7 @@ namespace SwitchboardPlugLocale {
              */
 
             try {
-                if (language.length == 2) {
-                    localectl_set_locale ("LANG=%s.UTF-8".printf (Utils.get_default_for_lang (language)), format);
-                } else {
-                    localectl_set_locale ("LANG=%s.UTF-8".printf (language), format);
-                }
+                localectl_set_locale ("LANG=%s".printf (language), format);
             } catch (Error e) {
                 warning (e.message);
             }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -179,20 +179,20 @@ namespace SwitchboardPlugLocale {
             return default_regions;
         }
 
-        public static Gee.ArrayList<string> get_regions (string language) {
-            Gee.ArrayList<string> regions = new Gee.ArrayList<string> ();
+        public static Gee.HashSet<string> get_locales_for_language_code (string language) {
+            Gee.HashSet<string> locales = new Gee.HashSet<string> ();
             foreach (string locale in get_installed_languages ()) {
-                string code, region;
-                if (!Gnome.Languages.parse_locale (locale, out code, out region, null, null)) {
+                string code;
+                if (!Gnome.Languages.parse_locale (locale, out code, null, null, null)) {
                     continue;
                 }
 
-                if (!regions.contains (region) && code == language) {
-                    regions.add (region);
+                if (code == language) {
+                    locales.add (locale);
                 }
             }
 
-            return regions;
+            return locales;
         }
 
         public static string translate_language (string lang) {

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -214,7 +214,6 @@ namespace SwitchboardPlugLocale.Widgets {
 
             var default_regions = yield Utils.get_default_regions ();
             var user_locale = lm.get_user_language ();
-            warning (user_locale);
 
             foreach (var locale in locales) {
                 string code;
@@ -228,7 +227,6 @@ namespace SwitchboardPlugLocale.Widgets {
                 region_store.append (out iter);
                 region_store.set (iter, 0, region_string, 1, locale);
 
-                warning (locale);
                 if (user_locale == locale) {
                     selected_locale_id = locale;
                     user_locale_found = true;

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -25,9 +25,6 @@ namespace SwitchboardPlugLocale.Widgets {
         private LocaleManager lm;
         private Preview preview;
         private string language;
-        private string selected_language = "";
-        private string selected_format = "";
-        private bool has_region;
         private EndLabel region_endlabel;
 
         private static GLib.Settings? temperature_settings = null;
@@ -126,17 +123,9 @@ namespace SwitchboardPlugLocale.Widgets {
             });
 
             set_button.clicked.connect (() => {
-                if (!has_region) {
-                    debug ("Setting user language to '%s'", language);
-                    lm.set_user_language (language);
-                    selected_language = language;
-                } else {
-                    var region = get_region ();
-                    debug ("Setting user language to '%s_%s'", language, region);
-                    lm.set_user_language ("%s_%s".printf (language, region));
-                    selected_language = "%s_%s".printf (language, region);
-                }
-                selected_format = get_format ();
+                var locale = get_selected_locale ();
+                debug ("Setting user language to '%s'", locale);
+                lm.set_user_language (locale);
 
                 compare ();
 
@@ -162,17 +151,17 @@ namespace SwitchboardPlugLocale.Widgets {
             }
         }
 
-        public string get_region () {
+        public string get_selected_locale () {
             Gtk.TreeIter iter;
-            string region;
+            string locale;
 
             if (!region_combobox.get_active_iter (out iter)) {
                 return "";
             }
 
-            region_store.get (iter, 1, out region);
+            region_store.get (iter, 1, out locale);
 
-            return region;
+            return locale;
         }
 
         public string get_format () {
@@ -197,13 +186,8 @@ namespace SwitchboardPlugLocale.Widgets {
         }
 
         private void compare () {
-            if (set_button != null && selected_language != "" && selected_format != "") {
-                var compare_language = language;
-                if (has_region) {
-                    compare_language = "%s_%s".printf (compare_language, get_region ());
-                }
-
-                if (compare_language == selected_language && selected_format == get_format ()) {
+            if (set_button != null) {
+                if (lm.get_user_language () == get_selected_locale () && lm.get_user_format () == get_format ()) {
                     set_button.sensitive = false;
                 } else {
                     set_button.sensitive = true;
@@ -220,53 +204,54 @@ namespace SwitchboardPlugLocale.Widgets {
             }
         }
 
-        public async void reload_regions (string language, Gee.ArrayList<string> regions) {
+        public async void reload_locales (string language, Gee.HashSet<string> locales) {
             this.language = language;
-            int selected_region = 0;
+            string? selected_locale_id = null;
+            bool user_locale_found = false;
+            int locales_added = 0;
 
             region_store.clear ();
 
-            int i = 0;
-            has_region = false;
-            foreach (var region in regions) {
-                has_region = true;
-                var region_string = Utils.translate_region (language, region, language);
+            var default_regions = yield Utils.get_default_regions ();
+            var user_locale = lm.get_user_language ();
+            warning (user_locale);
+
+            foreach (var locale in locales) {
+                string code;
+                if (!Gnome.Languages.parse_locale (locale, null, out code, null, null)) {
+                    continue;
+                }
+
+                var region_string = Utils.translate_region (language, code, language);
 
                 var iter = Gtk.TreeIter ();
                 region_store.append (out iter);
-                region_store.set (iter, 0, region_string, 1, region);
+                region_store.set (iter, 0, region_string, 1, locale);
 
-                if (lm.get_user_language ().length == 5 && lm.get_user_language ().slice (0, 2) == language
-                    && lm.get_user_language ().slice (3, 5) == region) {
-                        selected_region = i;
+                warning (locale);
+                if (user_locale == locale) {
+                    selected_locale_id = locale;
+                    user_locale_found = true;
                 }
 
-                var default_regions = yield Utils.get_default_regions ();
-                if (default_regions.has_key (language) && lm.get_user_language ().slice (0, 2) != language
-                && default_regions.@get (language) == "%s_%s".printf (language, region)) {
-                    selected_region = i;
+                if (!user_locale_found && default_regions.has_key (language)) {
+                    if (locale.has_prefix (default_regions[language])) {
+                        selected_locale_id = locale;
+                    }
                 }
 
-                i++;
+                locales_added++;
             }
 
-            region_combobox.active = selected_region;
+            region_combobox.id_column = 1;
+            region_combobox.sensitive = locales_added > 1;
+            if (selected_locale_id != null) {
+                region_combobox.active_id = selected_locale_id;
+            } else {
+                region_combobox.active = 0;
+            }
 
             region_store.set_sort_column_id (0, Gtk.SortType.ASCENDING);
-
-            if (i == 0) {
-                region_endlabel.hide ();
-                region_combobox.hide ();
-            } else {
-                region_endlabel.show ();
-                region_combobox.show ();
-            }
-
-            if (selected_language == "" && has_region) {
-                selected_language = "%s_%s".printf (language, get_region ());
-            } else if (selected_language == "" && !has_region) {
-                selected_language = language;
-            }
 
             compare ();
         }
@@ -304,10 +289,6 @@ namespace SwitchboardPlugLocale.Widgets {
 
             format_store.set_sort_column_id (0, Gtk.SortType.ASCENDING);
 
-            if (selected_format == "") {
-                selected_format = get_format ();
-            }
-
             compare ();
         }
 
@@ -316,13 +297,11 @@ namespace SwitchboardPlugLocale.Widgets {
         }
 
         private void on_applied_to_system () {
-            if (!has_region) {
-                debug ("Setting system language to '%s' and format to '%s'", language, get_format ());
-                lm.apply_to_system (language, get_format ());
-            } else {
-                debug ("Setting system language to '%s_%s' and format to '%s'", language, get_region (), get_format ());
-                lm.apply_to_system ("%s_%s".printf (language, get_region ()), get_format ());
-            }
+            var selected_locale = get_selected_locale ();
+            var selected_format = get_format ();
+            debug ("Setting system language to '%s' and format to '%s'", selected_locale, selected_format);
+            lm.apply_to_system (selected_locale, selected_format);
+
             settings_changed ();
         }
     }

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -73,13 +73,13 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
 
                 var selected_language_code = list_box.get_selected_language_code ();
-                var regions = Utils.get_regions (selected_language_code);
+                var locales = Utils.get_locales_for_language_code (selected_language_code);
 
                 debug ("reloading Settings widget for language '%s'".printf (selected_language_code));
-                locale_setting.reload_regions (selected_language_code, regions);
+                locale_setting.reload_locales (selected_language_code, locales);
                 locale_setting.reload_labels (selected_language_code);
 
-                if (selected_language_code == locale_manager.get_user_language ().slice (0, 2)) {
+                if (locale_manager.get_user_language () in locales) {
                     remove_button.sensitive = false;
                 } else {
                     remove_button.sensitive = true;


### PR DESCRIPTION
Fixes #143 

In many cases we were assembling the locale string to set on the user in accounts service manually. For example, we would get the language code (e.g. `en`) and the region code (e.g. `US`) and assemble them together into `en_US`, in some cases checking that they were exactly 2 characters long. There are some codes that are 3 letters, so this would have caused issues with those locales.

More problematic is that setting `en_US` or `de_DE` as a user's AccountsService language on Fedora causes rather big issues with localisation as the AccountsService documentation states it expects the setting to include the codepage (i.e. `de_DE.UTF-8`). I believe that the Ubuntu version of AccountsService has been patched in some way to prevent those issues from occuring here.

Either way, it's considerably easier if we just stop doing manual assembly of these locale strings and just take them as they come from `libgnome-desktop`. All locales from there are provided with the language code, region code and codepage in the format `de_DE.UTF-8`. So lets store those directly in the treestore for our combobox, and use that directly with AccountsService.

To test:
* Check that the current language and region is still detected correctly when opening the plug
* Check that changing your user's language and/or region still works correctly
* Check that changing the system's language and/or region still works correctly

