### PR TITLE
Select correct format after install/remove

### DIFF
--- a/data/io.elementary.switchboard.locale.appdata.xml.in
+++ b/data/io.elementary.switchboard.locale.appdata.xml.in
@@ -7,6 +7,14 @@
   <icon type="stock">preferences-desktop-locale</icon>
   <translation type="gettext">locale-plug</translation>
   <releases>
+    <release version="2.5.6" date="2021-11-04" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Ensure "Formats" dropdown remains correct after installing or removing languages</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.5.5" date="2021-10-26" urgency="medium">
       <description>
         <p>Fixes:</p>
@@ -18,7 +26,7 @@
           <li>Better support for non-Ubuntu based distributions</li>
           <li>Updated translations</li>
         </ul>
-      </description>       
+      </description>
     </release>
     <release version="2.5.4" date="2021-07-14" urgency="medium">
       <description>

--- a/src/LocaleManager.vala
+++ b/src/LocaleManager.vala
@@ -143,7 +143,7 @@ namespace SwitchboardPlugLocale {
         public string get_user_format () {
             // The `formats_locale` property is specific to Ubuntu, so check it exists before
             // returning the value
-            if (account_proxy.formats_locale != null) {
+            if (account_proxy.formats_locale != null && account_proxy.formats_locale != "") {
                 return account_proxy.formats_locale;
             }
 

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -80,12 +80,10 @@ namespace SwitchboardPlugLocale {
             }
 
             installer.install_finished.connect ((langcode) => {
-                langs.add (langcode);
                 reload.begin ();
             });
 
             installer.remove_finished.connect ((langcode) => {
-                langs.remove (langcode);
                 reload.begin ();
             });
 

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -257,9 +257,9 @@ namespace SwitchboardPlugLocale.Widgets {
         public void reload_formats (Gee.ArrayList<string>? locales) {
             format_store.clear ();
             var user_format = lm.get_user_format ();
-            int format_id = 0;
 
             int i = 0;
+            string? active_id = null;
             foreach (var locale in locales) {
                 string country = Gnome.Languages.get_country_from_locale (locale, null);
 
@@ -269,15 +269,20 @@ namespace SwitchboardPlugLocale.Widgets {
                     format_store.set (iter, 0, country, 1, locale);
 
                     if (locale == user_format) {
-                        format_id = i;
+                        active_id = locale;
                     }
 
                     i++;
                 }
             }
 
+            format_combobox.id_column = 1;
             format_combobox.sensitive = i != 1; // set to unsensitive if only have one item
-            format_combobox.active = format_id;
+            if (active_id != null) {
+                format_combobox.active_id = active_id;
+            } else {
+                format_combobox.active = 0;
+            }
 
             format_store.set_sort_column_id (0, Gtk.SortType.ASCENDING);
 


### PR DESCRIPTION
I've broken out part of #147 for this

Fixes #83 

**In `LocaleManager.vala`:**
Make sure we fall back to our alternative ways of getting the user's formats if its not set on AccountsService.

**In `Plug.vala`:**
Since the `langs` array is overwritten by the `reload` method, it doesn't make sense to add/remove stuff first.

**In `LocaleSetting.vala`:**
Since the tree store is sorted alphabetically on the human readable name of the language (which could be translated), it doesn't make sense to try and select the active one by index, because the indexes could change on sort. So we use the locale key to select the active entry.

