### PR TITLE
Removed ellipsis character from "Keyboard Settings…" button in all languages

### DIFF
--- a/po/aa.po
+++ b/po/aa.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ab.po
+++ b/po/ab.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ae.po
+++ b/po/ae.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/af.po
+++ b/po/af.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ak.po
+++ b/po/ak.po
@@ -130,7 +130,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Dane kɔ keyboard no ho nhyehyɛee"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/am.po
+++ b/po/am.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/an.po
+++ b/po/an.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/as.po
+++ b/po/as.po
@@ -135,5 +135,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/av.po
+++ b/po/av.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ay.po
+++ b/po/ay.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ba.po
+++ b/po/ba.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Задаване на език за екрана за вписване, гости и нови потребители"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/bh.po
+++ b/po/bh.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bi.po
+++ b/po/bi.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bm.po
+++ b/po/bm.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -139,7 +139,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Cameras"

--- a/po/bo.po
+++ b/po/bo.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/br.po
+++ b/po/br.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -133,7 +133,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Postavi jezik za ekran prijave, račun gosta i nove korisničke račune"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Podešavanja tastature…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ca.po
+++ b/po/ca.po
@@ -133,7 +133,7 @@ msgstr ""
 "comptes d'usuari nous."
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Paràmetres del teclat…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ce.po
+++ b/po/ce.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ch.po
+++ b/po/ch.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -128,7 +128,7 @@ msgstr "زمان بۆ پەڕەی چونەژوورەوە ، هەژمارەی می
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "ڕیکخستنی گۆڕین تختەکلیل"
 
 #~ msgid "Language: "

--- a/po/co.po
+++ b/po/co.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/cr.po
+++ b/po/cr.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Použít jazyk pro přihlašovací obrazovku, účet hosta a nové uživatele"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Nastavení klávesnice…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/cu.po
+++ b/po/cu.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/cv.po
+++ b/po/cv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/cy.po
+++ b/po/cy.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Angiv sprog for loginskærm, gæstekonto, og nye brugerkonti"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Tastaturindstillinger…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/de.po
+++ b/po/de.po
@@ -132,7 +132,7 @@ msgstr ""
 "Sprache für Anmelde-Bildschirm, Gast- und neue Benutzerkonten festlegen"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Tastatureinstellungen …"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/dv.po
+++ b/po/dv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/dz.po
+++ b/po/dz.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ee.po
+++ b/po/ee.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -135,7 +135,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Αλλαγή σε ρυθμίσεις πληκτρολογίου"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -135,8 +135,8 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Set language for login screen, guest account and new user accounts"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
-msgstr "Keyboard Settings…"
+msgid "Keyboard Settings"
+msgstr "Keyboard Settings"
 
 #~ msgid "Some settings require administrator rights to be changed"
 #~ msgstr "Some settings require administrator rights to be changed"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -131,8 +131,8 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Set language for login screen, guest account, and new user accounts"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
-msgstr "Keyboard Settings…"
+msgid "Keyboard Settings"
+msgstr "Keyboard Settings"
 
 #~ msgid "Some settings require administrator rights to be changed"
 #~ msgstr "Some settings require administrator rights to be changed"

--- a/po/eo.po
+++ b/po/eo.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Difini lingvon de la ensaluta ekrano, gasta konto, kaj nova uzanto"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Klavaraj agordoj…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/es.po
+++ b/po/es.po
@@ -133,7 +133,7 @@ msgstr ""
 "usuario nuevas"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Configuración del teclado…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/et.po
+++ b/po/et.po
@@ -135,7 +135,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Klaviatuuri seaded…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/eu.po
+++ b/po/eu.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/fa.po
+++ b/po/fa.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ff.po
+++ b/po/ff.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Aseta kieli kirjautumisnäkymään, vierastilille ja uusille käyttäjille"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Näppäimistön asetukset…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/fj.po
+++ b/po/fj.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/fo.po
+++ b/po/fo.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -135,7 +135,7 @@ msgstr ""
 "nouveaux comptes utilisateur"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Paramètres du clavier…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/fy.po
+++ b/po/fy.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/gd.po
+++ b/po/gd.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/gn.po
+++ b/po/gn.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -134,5 +134,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/gv.po
+++ b/po/gv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ha.po
+++ b/po/ha.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "הגדרת שפה למסך הכניסה, לחשבון האורח ולחשבונות של משתמשים חדשים"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "הגדרות מקלדת…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/hi.po
+++ b/po/hi.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ho.po
+++ b/po/ho.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -136,7 +136,7 @@ msgstr "Postavi jezik za zaslon prijave, račun gosta i nove korisničke račune
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Prebaci na postavke tipkovnice"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ht.po
+++ b/po/ht.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -133,7 +133,7 @@ msgstr ""
 "felhasználói fiókokhoz"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Billentyűzetbeállítások…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/hy.po
+++ b/po/hy.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/hz.po
+++ b/po/hz.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Tetapkan bahasa untuk layar masuk, akun tamu, dan akun pengguna baru"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Pengaturan Papan Ketik…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ie.po
+++ b/po/ie.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ig.po
+++ b/po/ig.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ii.po
+++ b/po/ii.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ik.po
+++ b/po/ik.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/io.po
+++ b/po/io.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -133,7 +133,7 @@ msgstr ""
 "account"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Impostazioni della tastiera…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/iu.po
+++ b/po/iu.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -133,7 +133,7 @@ msgstr ""
 "定します"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "キーボードの設定…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/jv.po
+++ b/po/jv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -131,7 +131,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "კლავიატურის პარამეტრებზე გადასვლა"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/kg.po
+++ b/po/kg.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ki.po
+++ b/po/ki.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/kj.po
+++ b/po/kj.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -136,5 +136,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/kl.po
+++ b/po/kl.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -134,5 +134,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "로그인 화면, 손님 계정과 새로운 사용자 계정을 위한 언어 설정"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "키보드 설정…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/kr.po
+++ b/po/kr.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ks.po
+++ b/po/ks.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ku.po
+++ b/po/ku.po
@@ -127,7 +127,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Language: "

--- a/po/kv.po
+++ b/po/kv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/kw.po
+++ b/po/kw.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ky.po
+++ b/po/ky.po
@@ -134,5 +134,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/la.po
+++ b/po/la.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/lb.po
+++ b/po/lb.po
@@ -126,5 +126,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/lg.po
+++ b/po/lg.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/li.po
+++ b/po/li.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ln.po
+++ b/po/ln.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/lo.po
+++ b/po/lo.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/locale-plug.pot
+++ b/po/locale-plug.pot
@@ -128,5 +128,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -135,7 +135,7 @@ msgstr ""
 "paskyroms"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Klaviatūros nustatymai…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/lu.po
+++ b/po/lu.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mg.po
+++ b/po/mg.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mh.po
+++ b/po/mh.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mi.po
+++ b/po/mi.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -135,5 +135,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mn.po
+++ b/po/mn.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mo.po
+++ b/po/mo.po
@@ -130,7 +130,7 @@ msgstr ""
 "de utilizator"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Setările tastaturii …"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/mr.po
+++ b/po/mr.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "लॉगिन स्क्रीन, अतिथी खाते आणि नवीन वापरकर्ता खात्यांसाठी भाषा सेट करा"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "कीबोर्ड सेटिंग्ज …"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ms.po
+++ b/po/ms.po
@@ -130,5 +130,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/mt.po
+++ b/po/mt.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/my.po
+++ b/po/my.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/na.po
+++ b/po/na.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -133,7 +133,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Velg språket for innloggingsskjermen, gjestekonto og nye brukerkontoer"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Tastaturinnstillinger…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/nd.po
+++ b/po/nd.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ne.po
+++ b/po/ne.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ng.po
+++ b/po/ng.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -132,7 +132,7 @@ msgstr ""
 "Zet de taal voor het aanmeldscherm, het gast account en nieuwe gebruikers"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Toetsenbordinstellingen…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/nn.po
+++ b/po/nn.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Vel språket for innloggingsskjermen, gjestekonto og nye brukarkontoar"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Tastaturinnstillingar…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/no.po
+++ b/po/no.po
@@ -117,5 +117,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/nr.po
+++ b/po/nr.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/nv.po
+++ b/po/nv.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ny.po
+++ b/po/ny.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/oj.po
+++ b/po/oj.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/om.po
+++ b/po/om.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/or.po
+++ b/po/or.po
@@ -133,5 +133,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/os.po
+++ b/po/os.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -137,5 +137,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/pi.po
+++ b/po/pi.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Ustaw język ekranu logowania, konta gościa i nowych kont użytkowników"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Ustawienia klawiatury…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ps.po
+++ b/po/ps.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -133,7 +133,7 @@ msgstr ""
 "contas de utilizador"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Definições do teclado…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -133,7 +133,7 @@ msgstr ""
 "usuário"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Configurações do Teclado…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/qu.po
+++ b/po/qu.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/rm.po
+++ b/po/rm.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/rn.po
+++ b/po/rn.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -132,5 +132,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Выбрать язык для экрана входа, гостевого и новых аккаунтов"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Настройки клавиатуры…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/rue.po
+++ b/po/rue.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/rw.po
+++ b/po/rw.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sa.po
+++ b/po/sa.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sc.po
+++ b/po/sc.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sd.po
+++ b/po/sd.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/se.po
+++ b/po/se.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sg.po
+++ b/po/sg.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -126,5 +126,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -133,7 +133,7 @@ msgstr ""
 "účty"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Nastavenia klávesnice…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/sl.po
+++ b/po/sl.po
@@ -133,7 +133,7 @@ msgstr ""
 "Nastavi jezik za prijavni zaslon, račun gosta in račun novih uporabnikov"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Nastavitve tipkovnice…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/sm.po
+++ b/po/sm.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sma.po
+++ b/po/sma.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sn.po
+++ b/po/sn.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/so.po
+++ b/po/so.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -135,7 +135,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Kalo tek rregullimet e tastierës"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/sr.po
+++ b/po/sr.po
@@ -133,7 +133,7 @@ msgstr ""
 "корисника"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Подешавања тастатуре…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ss.po
+++ b/po/ss.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/st.po
+++ b/po/st.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/su.po
+++ b/po/su.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -133,7 +133,7 @@ msgstr ""
 "Ställ in språk för inloggningsskärmen, gästkontot och nya användarkonton"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Tangentbordsinställningar…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/sw.po
+++ b/po/sw.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/szl.po
+++ b/po/szl.po
@@ -123,5 +123,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -131,5 +131,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -136,5 +136,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tg.po
+++ b/po/tg.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -132,7 +132,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ti.po
+++ b/po/ti.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tk.po
+++ b/po/tk.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tl.po
+++ b/po/tl.po
@@ -129,7 +129,7 @@ msgstr ""
 "account"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Language: "

--- a/po/tn.po
+++ b/po/tn.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/to.po
+++ b/po/to.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "Misafir ve yeni kullanıcı hesapları için giriş ekranı dilini ayarla"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Klavye Ayarları…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ts.po
+++ b/po/ts.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tt.po
+++ b/po/tt.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/tw.po
+++ b/po/tw.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ty.po
+++ b/po/ty.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -129,7 +129,7 @@ msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
 #, fuzzy
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "كۇنۇپكا تاختىسى تەكشەكلىرىگە يۆتكەش"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/uk.po
+++ b/po/uk.po
@@ -134,7 +134,7 @@ msgstr ""
 "облікових записів користувачів"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "Налаштування клавіатури…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/ur.po
+++ b/po/ur.po
@@ -125,7 +125,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""
 
 #~ msgid "Authentication is required to manage locale settings"

--- a/po/uz.po
+++ b/po/uz.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/ve.po
+++ b/po/ve.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -129,5 +129,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/vo.po
+++ b/po/vo.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/wo.po
+++ b/po/wo.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/xh.po
+++ b/po/xh.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/yi.po
+++ b/po/yi.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/yo.po
+++ b/po/yo.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/za.po
+++ b/po/za.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -116,5 +116,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "设置登录界面、访客账户和新账户的语言"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "键盘设置…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -131,7 +131,7 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr "為登入畫面、訪客帳號、和新使用者帳號設定預設語言"
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr "鍵盤設定…"
 
 #~ msgid "Some settings require administrator rights to be changed"

--- a/po/zu.po
+++ b/po/zu.po
@@ -124,5 +124,5 @@ msgid "Set language for login screen, guest account and new user accounts"
 msgstr ""
 
 #: src/Widgets/LocaleSetting.vala:108
-msgid "Keyboard Settings…"
+msgid "Keyboard Settings"
 msgstr ""

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -105,7 +105,7 @@ namespace SwitchboardPlugLocale.Widgets {
             var set_system_button = new Gtk.Button.with_label (_("Set System Language"));
             set_system_button.tooltip_text = _("Set language for login screen, guest account and new user accounts");
 
-            var keyboard_button = new Gtk.Button.with_label (_("Keyboard Settings…"));
+            var keyboard_button = new Gtk.Button.with_label (_("Keyboard Settings"));
 
             action_area.add (keyboard_button);
             action_area.add (set_system_button);


### PR DESCRIPTION
The Keyboard Settings button had the `…` character at the end of the label but none of the other buttons had it. I felt that removing the ellipsis from that button would make the button blend in with the rest of the UI, so I replaced the word `Keyboard Settings…` with `Keyboard Settings` in the entire repository.