### PR TITLE
installer: Don't trim language codes

### DIFF
--- a/data/io.elementary.switchboard.locale.appdata.xml.in
+++ b/data/io.elementary.switchboard.locale.appdata.xml.in
@@ -7,6 +7,14 @@
   <icon type="stock">preferences-desktop-locale</icon>
   <translation type="gettext">locale-plug</translation>
   <releases>
+    <release version="2.5.7" date="2022-04-12" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Support installation and removal of languages with 3-letter codes</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.5.6" date="2021-11-18" urgency="medium">
       <description>
         <p>Fixes:</p>

--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -202,7 +202,7 @@ public class SwitchboardPlugLocale.Installer.UbuntuInstaller : Object {
 
         try {
             Process.spawn_sync (null,
-                {LANGUAGE_CHECKER, "-l", langcode.substring (0, 2) , null},
+                {LANGUAGE_CHECKER, "-l", langcode, null},
                 Environ.get (),
                 SpawnFlags.SEARCH_PATH,
                 null,
@@ -237,7 +237,7 @@ public class SwitchboardPlugLocale.Installer.UbuntuInstaller : Object {
 
         try {
             Process.spawn_sync (null,
-                {LANGUAGE_CHECKER, "--show-installed", "-l", langcode.substring (0, 2) , null},
+                {LANGUAGE_CHECKER, "--show-installed", "-l", langcode, null},
                 Environ.get (),
                 SpawnFlags.SEARCH_PATH,
                 null,


### PR DESCRIPTION
We cannot assume that language codes will be 2 characters long. This prevents the installation and removal of languages that have 3 letter codes and/or additional variants.

To test:
* With master, try installing the "Tatar, Crimean" (`crh`) language.
* Note that no progress indicator appears, and the language is not available after "installation". There is another bug that prevents the list updating after changes (#149), but even after a restart of the plug, "Tatar, Crimean" will not be available.
* Install this branch and try again.
* Note that the progress window does indeed appear this time
* After a restart of the plug, the language should be available.