### PR TITLE
languagelist: Add Kurdish, Central

### DIFF
--- a/data/languagelist
+++ b/data/languagelist
@@ -15,6 +15,7 @@ bo
 br
 bs
 ca
+ckb
 crh
 cs
 csb


### PR DESCRIPTION
Fixes #157 

Note that this is enough to get the language to show, but it will not be usable until #156 is also merged.