### PR TITLE
Display polkit in translated texts

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -7,7 +7,7 @@ configured_policy_file = configure_file(
 i18n.merge_file(
     input: configured_policy_file,
     output: 'io.elementary.switchboard.locale.policy',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.source_root(), 'po'),
     install: true,
     install_dir: polkit_actiondir
 )

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,3 +1,4 @@
+data/io.elementary.switchboard.locale.policy.in.in
 src/Plug.vala
 src/ProgressDialog.vala
 src/Utils.vala

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,1 @@
 data/io.elementary.switchboard.locale.appdata.xml.in
-data/io.elementary.switchboard.locale.policy.in.in


### PR DESCRIPTION
# Before
![before](https://user-images.githubusercontent.com/26003928/166243568-b2707918-3f96-44d6-b5e1-213fc11e7468.png)

The description text in the Polkit dialog "Authentication is required to manage locale settings" is not shown as translated.

#After
![after](https://user-images.githubusercontent.com/26003928/166243559-6ddb3270-e9ce-443f-86f1-512fb6a4386b.png)

Moving the translation domain of the policy file, now the text is shown as translated in the user language.