### PR TITLE
POTFILES: Update the suffix of the policy file

### DIFF
--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,2 @@
 data/io.elementary.switchboard.locale.appdata.xml.in
-data/io.elementary.switchboard.locale.policy.in.in
+data/io.elementary.switchboard.locale.policy.in


### PR DESCRIPTION
Fixes the Gettext Actions [failing](https://github.com/elementary/switchboard-plug-locale/runs/6284028893?check_suite_focus=true) in the latest master branch.