### PR TITLE
LocaleSetting: absorb restart infobar

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -19,7 +19,6 @@ namespace SwitchboardPlugLocale {
         private Gtk.Box box;
         Widgets.LocaleView view;
 
-        public Gtk.InfoBar infobar;
         public Gtk.InfoBar missing_lang_infobar;
 
         private Installer.UbuntuInstaller installer;
@@ -74,8 +73,6 @@ namespace SwitchboardPlugLocale {
             unowned LocaleManager lm = LocaleManager.get_default ();
             if (lm.is_connected) {
                 reload.begin ();
-
-                infobar.revealed = false;
             }
 
             installer.install_finished.connect ((langcode) => {
@@ -116,13 +113,6 @@ namespace SwitchboardPlugLocale {
 
         // Wires up and configures initial UI
         private void setup_ui () {
-            // Gtk.InfoBar for informing about necessary log-out/log-in
-            var label = new Gtk.Label (_("Some changes will not take effect until you log out"));
-            infobar = new Gtk.InfoBar ();
-            infobar.message_type = Gtk.MessageType.WARNING;
-            infobar.revealed = false;
-            infobar.add_child (label);
-
             // Gtk.InfoBar for language support installation
             var missing_label = new Gtk.Label (_("Language support is not installed completely"));
 
@@ -135,7 +125,6 @@ namespace SwitchboardPlugLocale {
             view = new Widgets.LocaleView (this);
 
             box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-            box.append (infobar);
             box.append (missing_lang_infobar);
             box.append (view);
 

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -19,6 +19,7 @@ namespace SwitchboardPlugLocale.Widgets {
         private Gtk.Button set_button;
         private Gtk.ComboBox format_combobox;
         private Gtk.ComboBox region_combobox;
+        private Gtk.InfoBar restart_infobar;
         private Gtk.ListStore format_store;
         private Gtk.ListStore region_store;
 
@@ -28,8 +29,6 @@ namespace SwitchboardPlugLocale.Widgets {
         private Gtk.Label region_endlabel;
 
         private static GLib.Settings? temperature_settings = null;
-
-        public signal void settings_changed ();
 
         public LocaleSetting () {
             Object (icon: new ThemedIcon ("preferences-desktop-locale"));
@@ -73,6 +72,13 @@ namespace SwitchboardPlugLocale.Widgets {
                 halign = Gtk.Align.END
             };
 
+            restart_infobar = new Gtk.InfoBar () {
+                message_type = WARNING,
+                revealed = false
+            };
+            restart_infobar.add_child (new Gtk.Label (_("Some changes will not take effect until you log out")));
+            restart_infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
+
             var content_area = new Gtk.Grid () {
                 column_spacing = 6,
                 row_spacing = 12
@@ -82,6 +88,7 @@ namespace SwitchboardPlugLocale.Widgets {
             content_area.attach (formats_label, 0, 3);
             content_area.attach (format_combobox, 1, 3, 2);
             content_area.attach (preview, 0, 5, 3);
+            content_area.attach (restart_infobar, 0, 6, 3);
 
             child = content_area;
 
@@ -155,7 +162,7 @@ namespace SwitchboardPlugLocale.Widgets {
                 debug ("Setting user format to '%s'", format);
                 lm.set_user_format (format);
 
-                settings_changed ();
+                restart_infobar.revealed = true;
             });
 
             set_system_button.clicked.connect (() => {
@@ -210,6 +217,7 @@ namespace SwitchboardPlugLocale.Widgets {
         private void compare () {
             if (set_button != null) {
                 if (lm.get_user_language () == get_selected_locale () && lm.get_user_format () == get_format ()) {
+                    restart_infobar.revealed = false;
                     set_button.sensitive = false;
                 } else {
                     set_button.sensitive = true;
@@ -312,7 +320,7 @@ namespace SwitchboardPlugLocale.Widgets {
             debug ("Setting system language to '%s' and format to '%s'", selected_locale, selected_format);
             lm.apply_to_system (selected_locale, selected_format);
 
-            settings_changed ();
+            restart_infobar.revealed = true;
         }
     }
 }

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -57,9 +57,6 @@ namespace SwitchboardPlugLocale.Widgets {
             sidebar.append (action_bar);
 
             locale_setting = new LocaleSetting ();
-            locale_setting.settings_changed.connect (() => {
-                plug.infobar.revealed = true;
-            });
 
             var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
                 start_child = sidebar,


### PR DESCRIPTION
![Screenshot from 2024-03-07 11 11 18](https://github.com/elementary/switchboard-plug-locale/assets/7277719/b293a9ee-6b0c-42ce-b4b6-392a0832252a)

Trying to get infobars off the top of the screen since window controls will be in the page header