### PR TITLE
LocaleSettings: absorb missing_lang_infobar

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -20,7 +20,6 @@ namespace SwitchboardPlugLocale {
         Widgets.LocaleView view;
 
         public Gtk.InfoBar infobar;
-        public Gtk.InfoBar missing_lang_infobar;
 
         private Installer.UbuntuInstaller installer;
         private ProgressDialog progress_dialog = null;
@@ -86,7 +85,6 @@ namespace SwitchboardPlugLocale {
                 reload.begin ();
             });
 
-            installer.check_missing_finished.connect (on_check_missing_finished);
             installer.progress_changed.connect (on_progress_changed);
         }
 
@@ -123,34 +121,11 @@ namespace SwitchboardPlugLocale {
             infobar.revealed = false;
             infobar.add_child (label);
 
-            // Gtk.InfoBar for language support installation
-            var missing_label = new Gtk.Label (_("Language support is not installed completely"));
-
-            missing_lang_infobar = new Gtk.InfoBar ();
-            missing_lang_infobar.message_type = Gtk.MessageType.WARNING;
-            missing_lang_infobar.revealed = false;
-            missing_lang_infobar.add_button (_("Complete Installation"), 0);
-            missing_lang_infobar.add_child (missing_label);
-
             view = new Widgets.LocaleView (this);
 
             box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             box.append (infobar);
-            box.append (missing_lang_infobar);
             box.append (view);
-
-            missing_lang_infobar.response.connect (() => {
-                missing_lang_infobar.revealed = false;
-                installer.install_missing_languages ();
-            });
-        }
-
-        private void on_check_missing_finished (string[] missing) {
-            if (missing.length > 0) {
-                missing_lang_infobar.revealed = true;
-            } else {
-                missing_lang_infobar.revealed = false;
-            }
         }
 
         private void on_progress_changed (int progress) {

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -76,7 +76,6 @@ namespace SwitchboardPlugLocale.Widgets {
                 halign = Gtk.Align.END
             };
 
-
             var missing_label = new Gtk.Label (_("Language support is not installed completely"));
 
             missing_lang_infobar = new Gtk.InfoBar () {

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -17,6 +17,7 @@
 namespace SwitchboardPlugLocale.Widgets {
     public class LocaleSetting : Switchboard.SettingsPage {
         private Gtk.Button set_button;
+        private Gtk.InfoBar missing_lang_infobar;
         private Gtk.ComboBox format_combobox;
         private Gtk.ComboBox region_combobox;
         private Gtk.ListStore format_store;
@@ -73,6 +74,16 @@ namespace SwitchboardPlugLocale.Widgets {
                 halign = Gtk.Align.END
             };
 
+            var missing_label = new Gtk.Label (_("Language support is not installed completely"));
+
+            missing_lang_infobar = new Gtk.InfoBar () {
+                message_type = WARNING,
+                revealed = false
+            };
+            missing_lang_infobar.add_button (_("Complete Installation"), 0);
+            missing_lang_infobar.add_child (missing_label);
+            missing_lang_infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
+
             var content_area = new Gtk.Grid () {
                 column_spacing = 6,
                 row_spacing = 12
@@ -82,6 +93,7 @@ namespace SwitchboardPlugLocale.Widgets {
             content_area.attach (formats_label, 0, 3);
             content_area.attach (format_combobox, 1, 3, 2);
             content_area.attach (preview, 0, 5, 3);
+            content_area.attach (missing_lang_infobar, 0, 6, 3);
 
             child = content_area;
 
@@ -144,6 +156,13 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
             });
 
+            unowned var installer = Installer.UbuntuInstaller.get_default ();
+
+            missing_lang_infobar.response.connect (() => {
+                missing_lang_infobar.revealed = false;
+                installer.install_missing_languages ();
+            });
+
             set_button.clicked.connect (() => {
                 var locale = get_selected_locale ();
                 debug ("Setting user language to '%s'", locale);
@@ -165,6 +184,12 @@ namespace SwitchboardPlugLocale.Widgets {
 
                 on_applied_to_system ();
             });
+
+            installer.check_missing_finished.connect (on_check_missing_finished);
+        }
+
+        private void on_check_missing_finished (string[] missing) {
+            missing_lang_infobar.revealed = missing.length > 0;
         }
 
         static construct {


### PR DESCRIPTION
Same motivation as #191 

![Screenshot from 2024-03-08 09 17 00](https://github.com/elementary/switchboard-plug-locale/assets/7277719/845c8747-bb68-4d47-912f-ff140cbb08ac)