### PR TITLE
LocaleSetting: support GWeather4

### DIFF
--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -180,6 +180,8 @@ namespace SwitchboardPlugLocale.Widgets {
         static construct {
             if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather", true) != null) {
                 temperature_settings = new Settings ("org.gnome.GWeather");
+            } else if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather4", true) != null) {
+                temperature_settings = new Settings ("org.gnome.GWeather4");
             }
         }
 

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -178,10 +178,10 @@ namespace SwitchboardPlugLocale.Widgets {
         }
 
         static construct {
-            if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather", true) != null) {
-                temperature_settings = new Settings ("org.gnome.GWeather");
-            } else if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather4", true) != null) {
+            if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather4", true) != null) {
                 temperature_settings = new Settings ("org.gnome.GWeather4");
+            } else if (SettingsSchemaSource.get_default ().lookup ("org.gnome.GWeather", true) != null) {
+                temperature_settings = new Settings ("org.gnome.GWeather");
             }
         }
 


### PR DESCRIPTION
Setting path changed in OS 8. Is it worth supporting both?