### PR TITLE
Do not uninstall font packages with language

### DIFF
--- a/src/Installer/UbuntuInstaller.vala
+++ b/src/Installer/UbuntuInstaller.vala
@@ -224,8 +224,12 @@ public class SwitchboardPlugLocale.Installer.UbuntuInstaller : Object {
 
         var removable = new Gee.ArrayList<string> ();
         foreach (var packet in installed) {
-            if (!(packet in multilang_packs) && !(packet in missing_packs))
+            if (!(packet in multilang_packs) &&
+                !(packet in missing_packs) &&
+                !packet.contains ("font")
+            ) {
                 removable.add (packet);
+            }
         }
 
         return removable.to_array ();


### PR DESCRIPTION
Fixes #200 

A simplistic fix for the linked issue.  It might result in uninstalled and unwanted font packages but this is the lesser evil if no better solution can be found.

An alternative would be to add specific multilanguage fonts to the list of excluded packages for uninstalling but I am not sure what a complete list would be.