### PR TITLE
LocaleView: Fix access to UbuntuInstaller before initialization

### DIFF
--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -102,12 +102,13 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
             });
 
+            installer = Installer.UbuntuInstaller.get_default ();
+
             unowned var lm = LocaleManager.get_default ();
             if (lm.is_connected) {
                 reload.begin ();
             }
 
-            installer = Installer.UbuntuInstaller.get_default ();
             installer.progress_changed.connect (on_progress_changed);
 
             installer.install_finished.connect ((langcode) => {


### PR DESCRIPTION
Fixes the following message is shown in the terminal when opening the plug:

```
** (io.elementary.settings:18513): CRITICAL **: 11:32:40.212: switchboard_plug_locale_installer_ubuntu_installer_check_missing_languages: assertion 'self != NULL' failed
```

This is because we're calling `installer.check_missing_languages ()` before initializing `installer` variable.