### PR TITLE
blocklist: Add fcitx5-frontend-qt6

### DIFF
--- a/data/packages_blocklist
+++ b/data/packages_blocklist
@@ -21,6 +21,7 @@ fcitx5-frontend-gtk2
 fcitx5-frontend-gtk3
 fcitx5-frontend-gtk4
 fcitx5-frontend-qt5
+fcitx5-frontend-qt6
 fcitx5-module-cloudpinyin
 fonts-indic
 fonts-khmeros-core


### PR DESCRIPTION
Because we use IBus for a input method and want to prevent Fcitx things from being installed.