### PR TITLE
Fix some language and region names not shown in own languages

### DIFF
--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -54,7 +54,7 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.Box {
                 continue;
             }
 
-            add_language (code);
+            add_language (code, locale);
         }
 
         var row = listbox.get_first_child ();
@@ -67,9 +67,9 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.Box {
         }
     }
 
-    private void add_language (string code) {
+    private void add_language (string code, string locale) {
         if (!languages.has_key (code)) {
-            var language_string = Utils.translate (code, null);
+            var language_string = Utils.translate (code, locale);
 
             if (lm.get_user_language ().slice (0, 2) == code) {
                 languages[code] = new LanguageRow (code, language_string, true);

--- a/src/Widgets/LanguageListBox.vala
+++ b/src/Widgets/LanguageListBox.vala
@@ -109,6 +109,15 @@ public class SwitchboardPlugLocale.Widgets.LanguageListBox : Gtk.Box {
         }
     }
 
+    public string? get_selected_language_name () {
+        var selected_row = listbox.get_selected_row () as LanguageRow;
+        if (selected_row != null) {
+            return selected_row.text;
+        } else {
+            return null;
+        }
+    }
+
     private class LanguageRow : Gtk.ListBoxRow {
         public string code { get; construct; }
         public string text { get; construct; }

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -276,7 +276,7 @@ namespace SwitchboardPlugLocale.Widgets {
                     continue;
                 }
 
-                var region_string = Utils.translate_region (language, code, language);
+                var region_string = Utils.translate_region (language, code, locale);
 
                 var locale_object = new Locale (region_string, locale);
 

--- a/src/Widgets/LocaleSetting.vala
+++ b/src/Widgets/LocaleSetting.vala
@@ -325,8 +325,8 @@ namespace SwitchboardPlugLocale.Widgets {
             compare ();
         }
 
-        public void reload_labels (string language) {
-            title = Utils.translate (language, null);
+        public void reload_labels (string language_name) {
+            title = language_name;
         }
 
         private void on_applied_to_system () {

--- a/src/Widgets/LocaleView.vala
+++ b/src/Widgets/LocaleView.vala
@@ -89,11 +89,12 @@ namespace SwitchboardPlugLocale.Widgets {
                 }
 
                 var selected_language_code = list_box.get_selected_language_code ();
+                var selected_language_name = list_box.get_selected_language_name ();
                 var locales = Utils.get_locales_for_language_code (selected_language_code);
 
                 debug ("reloading Settings widget for language '%s'".printf (selected_language_code));
                 locale_setting.reload_locales.begin (selected_language_code, locales);
-                locale_setting.reload_labels (selected_language_code);
+                locale_setting.reload_labels (selected_language_name);
 
                 if (locale_manager.get_user_language () in locales) {
                     remove_button.sensitive = false;


### PR DESCRIPTION
Fixes #15

We set LANGUAGE environment variable and then call Gnome.Languages.get_language_from_locale or Gnome.Languages.get_country_from_code to get language and region names in their own languages.

However, we don't set LANGUAGE with both ISO 639 language code and ISO 3166 territory name (e.g. "ja_JP" or "zh_CN") here. Instead, we set it only with ISO 639 language code (e.g. "ja" or "zh").

Just setting language code doesn't work for some languages that has variants like Chinese and thus the Gnome.Languages APIs returns untranslated language names.

## After
![Screenshot from 2024-06-19 00-14-25](https://github.com/elementary/switchboard-plug-locale/assets/26003928/f7593fd0-a506-4408-9c1f-fc3e42dcf3b5)

## Before
![Screenshot from 2024-06-18 23-52-54](https://github.com/elementary/switchboard-plug-locale/assets/26003928/700c878c-ad70-4444-9693-16ddaf9ddbdb)
