### PR TITLE
meson: Fix wrong rename from metainfo.xml.in to appdata.xml

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -8,7 +8,7 @@ i18n.merge_file(
 
 i18n.merge_file(
     input: 'locale.metainfo.xml.in',
-    output: meson.project_name() + '.appdata.xml',
+    output: meson.project_name() + '.metainfo.xml',
     po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,


### PR DESCRIPTION
Seems like a leftover of #206; let's merge this easy fix before #237
